### PR TITLE
Redirect URL should alway use default port for the scheme.

### DIFF
--- a/lib/rack/ssl-enforcer.rb
+++ b/lib/rack/ssl-enforcer.rb
@@ -14,7 +14,7 @@ module Rack
       end
       
       if scheme
-        location = @options[:redirect_to] || @req.url.gsub(/^https?/, scheme)
+        location = @options[:redirect_to] || replace_scheme(@req, scheme).url
         body     = "<html><body>You are being <a href=\"#{location}\">redirected</a>.</body></html>"
         [301, { 'Content-Type' => 'text/html', 'Location' => location }, [body]]
       else
@@ -43,5 +43,15 @@ module Rack
       end
     end
     
+    def replace_scheme(req, scheme)
+      Rack::Request.new(req.env.merge(
+        'rack.url_scheme' => scheme,
+        'SERVER_PORT' => port_for(scheme).to_s
+      ))
+    end
+    
+    def port_for(scheme)
+      scheme == 'https' ? 443 : 80
+    end
   end
 end

--- a/test/test_rack-ssl-enforcer.rb
+++ b/test/test_rack-ssl-enforcer.rb
@@ -36,6 +36,12 @@ class TestRackSslEnforcer < Test::Unit::TestCase
       assert_equal 200, last_response.status
       assert_equal 'Hello world!', last_response.body
     end
+    
+    should 'use default https port when redirecting non-standard http port to ssl' do
+      get 'http://example.org:81/', {}, { 'rack.url_scheme' => 'http' }
+      assert_equal 301, last_response.status
+      assert_equal 'https://example.org/', last_response.location
+    end
   end
   
   context 'that has :redirect_to set' do
@@ -121,6 +127,12 @@ class TestRackSslEnforcer < Test::Unit::TestCase
       get 'https://www.example.org/login'
       assert_equal 200, last_response.status
       assert_equal 'Hello world!', last_response.body
+    end
+    
+    should 'use default https port when redirecting non-standard ssl port to http' do
+      get 'https://example.org:81/', {}, { 'rack.url_scheme' => 'https' }
+      assert_equal 301, last_response.status
+      assert_equal 'http://example.org/', last_response.location
     end
   end
   


### PR DESCRIPTION
Thanks for publishing rack-ssl-enforcer.

I have fixed it to work in my development environment, where normal HTTP is on port 8080 and HTTPS is on the default port 443.  Test cases are included.

Previous behavior, broken:
- `http://example.org:8080/` ⇒ `https://example.org:8080/`
- `https://example.org:4000/` ⇒ `http://example.org:4000/`  (:only + :strict)

Updated behavior, fixed:
- `http://example.org:8080/` ⇒ `https://example.org/`
- `https://example.org:4000/` ⇒ `http://example.org/`  (:only + :strict)

Given that a hostname cannot run HTTP and HTTPS on a single port, the port of the original request should not be preserved in the redirect location URL.

Cheers!
Paul
