### PR TITLE
Added :except option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rack-ssl-enforcer (0.1.9)
+    rack-ssl-enforcer (0.2.0)
 
 GEM
   remote: http://rubygems.org/
@@ -40,6 +40,3 @@ DEPENDENCIES
   rack-test (~> 0.5.4)
   shoulda (~> 2.11.3)
   test-unit (~> 2.1.1)
-
-METADATA
-  version: 1.0.6

--- a/README.rdoc
+++ b/README.rdoc
@@ -34,6 +34,12 @@ You can also define specific regex patterns or paths to redirect.
   config.middleware.use Rack::SslEnforcer, :only => /^\/admin\//
   config.middleware.use Rack::SslEnforcer, :only => "/login"
   config.middleware.use Rack::SslEnforcer, :only => ["/login", /\.xml$/]
+
+or define specific regex patterns or paths as exceptions.
+
+  config.middleware.use Rack::SslEnforcer, :except => /^\/admin\//
+  config.middleware.use Rack::SslEnforcer, :except => "/login"
+  config.middleware.use Rack::SslEnforcer, :except => ["/login", /\.xml$/]
   
 And force http for non-https path
 

--- a/lib/rack/ssl-enforcer.rb
+++ b/lib/rack/ssl-enforcer.rb
@@ -45,16 +45,24 @@ module Rack
       end
     end
     
+    # matches a path against a rule
+    # Accepts a string path, a regex matcher or an array of these
+    def match_rule?(options)
+      rules = [options].flatten
+      rules.any? do |pattern|
+        if pattern.is_a?(Regexp)
+          @req.path =~ pattern
+        else
+          @req.path[0, pattern.length] == pattern
+        end
+      end
+    end
+
     def enforce_ssl?(env)
       if @options[:only]
-        rules = [@options[:only]].flatten
-        rules.any? do |pattern|
-          if pattern.is_a?(Regexp)
-            @req.path =~ pattern
-          else
-            @req.path[0,pattern.length] == pattern
-          end
-        end
+        match_rule?(@options[:only])
+      elsif @options[:except]
+        !match_rule?(@options[:except])
       else
         true
       end


### PR DESCRIPTION
My sites are pretty much pure https, except for a small handful of pages. This :except option does the opposite of :only and lets me specify these paths.
