### PR TITLE
Disable HSTS when using strict

### DIFF
--- a/lib/rack/ssl-enforcer.rb
+++ b/lib/rack/ssl-enforcer.rb
@@ -20,7 +20,7 @@ module Rack
       elsif ssl_request?(env)
         status, headers, body = @app.call(env)
         flag_cookies_as_secure!(headers)
-        set_hsts_headers!(headers)
+        set_hsts_headers!(headers) if !@options[:strict]
         [status, headers, body]
       else
         @app.call(env)

--- a/test/rack-ssl-enforcer_test.rb
+++ b/test/rack-ssl-enforcer_test.rb
@@ -164,6 +164,11 @@ class TestRackSslEnforcer < Test::Unit::TestCase
       get 'http://www.example.org/'
       assert_equal ["id=1; path=/", "token=abc; path=/; secure; HttpOnly"], last_response.headers['Set-Cookie'].split("\n")
     end
+
+    should 'not set hsts' do
+      get 'http://www.example.org/'
+      assert !last_response.headers["Strict-Transport-Security"]
+    end
   end
   
   context 'that has hsts options set' do


### PR DESCRIPTION
When using :strict and HSTS, you'll get an infinite loop since the browser keeps trying to force it into SSL mode. As far as I see, you can't set HSTS on specific paths, so this disables it when using :strict instead.
