### PR TITLE
Make secure cookie flag optional

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -60,6 +60,18 @@ To set HSTS expiry and subdomain inclusion (defaults: one year, true). Strict op
   config.middleware.use Rack::SslEnforcer, :hsts => { :expires => 500, :subdomains => false }
   config.middleware.use Rack::SslEnforcer, :hsts => true # equivalent to { :expires => 31536000, :subdomains => true }
 
+Finally you might want to share a cookie based session between http and https.
+This is not possible by default with Rack::SslEnforcer for security reasons.
+See: [http://en.wikipedia.org/wiki/HTTP_cookie#Cookie_hijacking]
+
+Nevertheless, you can set the option :force_secure_cookies to false in order to be able to share a cookie based session between http and https:
+
+  config.middleware.use Rack::SslEnforcer, :only => "/login", :force_secure_cookies => false
+
+But be aware that if you do so, you have to make sure that the content of you cookie is encoded.
+This can be done using a coder with Rack::Session::Cookie.
+See: [https://github.com/rack/rack/blob/master/lib/rack/session/cookie.rb#L28-42]
+
 
 == TODO
 

--- a/lib/rack/ssl-enforcer.rb
+++ b/lib/rack/ssl-enforcer.rb
@@ -3,6 +3,7 @@ module Rack
 
     def initialize(app, options = {})
       @app, @options = app, options
+      $stderr.puts "WARN -- : The option :force_secure_cookies is set to false so make sure your cookies are encoded and that you understand the consequences (see documentation)" if options[:force_secure_cookies]==false
     end
 
     def call(env)
@@ -19,7 +20,7 @@ module Rack
         [301, { 'Content-Type' => 'text/html', 'Location' => location }, [body]]
       elsif ssl_request?(env)
         status, headers, body = @app.call(env)
-        flag_cookies_as_secure!(headers)
+        flag_cookies_as_secure!(headers) unless @options[:force_secure_cookies]==false
         set_hsts_headers!(headers) if @options[:hsts] && !@options[:strict]
         [status, headers, body]
       else

--- a/test/rack-ssl-enforcer_test.rb
+++ b/test/rack-ssl-enforcer_test.rb
@@ -700,5 +700,17 @@ class TestRackSslEnforcer < Test::Unit::TestCase
       assert !last_response.headers["Strict-Transport-Security"].include?("includeSubDomains")
     end
   end
+  
+  context 'that has force_secure_cookie option set to false' do
+    $stderr = StringIO.new
+    setup { mock_app :force_secure_cookies => false }
+    
+    should 'not secure cookies but warn the user of the consequences' do
+      get 'https://www.example.org/users/123/edit'
+      assert_equal ["id=1; path=/", "token=abc; path=/; secure; HttpOnly"], last_response.headers['Set-Cookie'].split("\n")
+      $stderr.rewind
+      assert_equal "WARN -- : The option :force_secure_cookies is set to false so make sure your cookies are encoded and that you understand the consequences (see documentation)\n", $stderr.read
+    end
+  end
 
 end


### PR DESCRIPTION
Hello,

After the discussion we had on the issue page with thibaudgg, here is my fork for having secure cookie flag optional.

It includes tests, a warning and documentation.

Let me know what you think.

Thank you very much,
Mig
