### PR TITLE
Custom ports, support for Rails 2.3/Rack 1.1

### DIFF
--- a/lib/rack/ssl-enforcer.rb
+++ b/lib/rack/ssl-enforcer.rb
@@ -148,8 +148,13 @@ module Rack
 
     # see http://en.wikipedia.org/wiki/HTTP_cookie#Cookie_theft_and_session_hijacking
     def flag_cookies_as_secure!(headers)
-      if headers['Set-Cookie']
-        headers['Set-Cookie'] = headers['Set-Cookie'].split("\n").map do |cookie|
+      if cookies = headers['Set-Cookie']
+        # Support Rails 2.3 / Rack 1.1 arrays as headers
+        if cookies.respond_to?(:split)
+          cookies = cookies.split("\n")
+        end
+
+        headers['Set-Cookie'] = cookies.map do |cookie|
           cookie !~ / secure;/ ? "#{cookie}; secure" : cookie
         end.join("\n")
       end


### PR DESCRIPTION
These two commits add one minor feature (the ability to redirect to a custom HTTP/HTTPS port) and implements an often-patched workaround for Rails 2.3.10+ weird implemention of headers['Set-Cookie'] being an array instead of a string.
