### PR TITLE
Fix Rails 2.3.x projects for (for real this time)

### DIFF
--- a/lib/rack/ssl-enforcer.rb
+++ b/lib/rack/ssl-enforcer.rb
@@ -150,7 +150,7 @@ module Rack
     def flag_cookies_as_secure!(headers)
       if cookies = headers['Set-Cookie']
         # Support Rails 2.3 / Rack 1.1 arrays as headers
-        if cookies.respond_to?(:split)
+        unless cookies.is_a?(Array)
           cookies = cookies.split("\n")
         end
 


### PR DESCRIPTION
My apologies on the earlier (broken) pull request. I neglected to account for the fact that Rails monkeypatches Array to have #split method, so although it passed the tests, it didn't actually work with a Rails 2.3.x project.
