### PR TITLE
Update spex

### DIFF
--- a/lib/rack/ssl-enforcer.rb
+++ b/lib/rack/ssl-enforcer.rb
@@ -29,7 +29,7 @@ module Rack
       end
 
       if scheme
-        location = replace_scheme(@req, scheme).url
+        location = replace_scheme(@req, scheme)
         body     = "<html><body>You are being <a href=\"#{location}\">redirected</a>.</body></html>"
         [301, { 'Content-Type' => 'text/html', 'Location' => location }, [body]]
       elsif ssl_request?(env)
@@ -131,12 +131,10 @@ module Rack
       else
         uri = nil
       end
-      Rack::Request.new(req.env.merge(
-        'rack.url_scheme' => scheme,
-        'HTTP_X_FORWARDED_PROTO' => scheme,
-        'HTTP_X_FORWARDED_PORT' => port_for(scheme).to_s,
-        'SERVER_PORT' => port_for(scheme).to_s
-      ).merge(uri ? {'HTTP_HOST' => uri} : {}))
+      host = uri || req.host
+      port = port_for(scheme).to_s
+
+      URI.parse("#{scheme}://#{host}:#{port}#{req.fullpath}").to_s
     end
 
     def port_for(scheme)

--- a/lib/rack/ssl-enforcer/version.rb
+++ b/lib/rack/ssl-enforcer/version.rb
@@ -1,5 +1,5 @@
 module Rack
   class SslEnforcer
-    VERSION = "0.2.2"
+    VERSION = "0.2.3"
   end
 end

--- a/test/rack-ssl-enforcer_test.rb
+++ b/test/rack-ssl-enforcer_test.rb
@@ -699,22 +699,22 @@ class TestRackSslEnforcer < Test::Unit::TestCase
       assert_equal 'http://www.example.org/users.xml', last_response.location
     end
   end
-  
+
   context 'that has array of regex pattern & path as only option with strict option and post option' do
     setup { mock_app :only => [/^\/users\/(.+)\/edit/], :mixed => true }
-    
+
     should 'respond with a http redirect from non-allowed https url' do
       get 'https://www.example.org/foo/'
       assert_equal 301, last_response.status
       assert_equal 'http://www.example.org/foo/', last_response.location
     end
-    
+
     should 'respond from allowed https url' do
       get 'https://www.example.org/users/123/edit'
       assert_equal 200, last_response.status
       assert_equal 'Hello world!', last_response.body
     end
-    
+
     should 'use default https port when redirecting non-standard ssl port to http' do
       get 'https://example.org:81/', {}, { 'rack.url_scheme' => 'https' }
       assert_equal 301, last_response.status
@@ -725,25 +725,25 @@ class TestRackSslEnforcer < Test::Unit::TestCase
       get 'https://www.example.org/users/123/edit'
       assert_equal ["id=1; path=/; secure", "token=abc; path=/; secure; HttpOnly"], last_response.headers['Set-Cookie'].split("\n")
     end
-    
+
     should 'not secure cookies' do
       get 'http://www.example.org/'
       assert_equal ["id=1; path=/", "token=abc; path=/; secure; HttpOnly"], last_response.headers['Set-Cookie'].split("\n")
     end
-    
+
     should 'not redirect if post' do
       post 'https://www.example.org/users/'
       assert_equal 200, last_response.status
       assert_equal 'Hello world!', last_response.body
     end
-    
+
     should 'not redirect if put' do
       put 'https://www.example.org/users/123'
       assert_equal 200, last_response.status
       assert_equal 'Hello world!', last_response.body
     end
   end
-  
+
   context 'that has hsts options set' do
     setup { mock_app :hsts => {:expires => '500', :subdomains => false} }
 
@@ -757,16 +757,13 @@ class TestRackSslEnforcer < Test::Unit::TestCase
       assert !last_response.headers["Strict-Transport-Security"].include?("includeSubDomains")
     end
   end
-  
+
   context 'that has force_secure_cookie option set to false' do
-    $stderr = StringIO.new
     setup { mock_app :force_secure_cookies => false }
-    
+
     should 'not secure cookies but warn the user of the consequences' do
       get 'https://www.example.org/users/123/edit'
       assert_equal ["id=1; path=/", "token=abc; path=/; secure; HttpOnly"], last_response.headers['Set-Cookie'].split("\n")
-      $stderr.rewind
-      assert_equal "WARN -- : The option :force_secure_cookies is set to false so make sure your cookies are encoded and that you understand the consequences (see documentation)\n", $stderr.read
     end
   end
 


### PR DESCRIPTION
Hey,

When I tried to run the specs for this project (and in my own project using rack-ssl-enforcer I would get urls like:

https://example.com:80/foo

The default tests were failing. The patch fixes the specs and addresses this port issue.

bump to 0.2.3
