### PR TITLE
Rewrite of enforce_ssl? and implementation of new options only_methods and except_methods.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -33,7 +33,7 @@ You might need the :redirect_to option if the requested URL can't be determined 
 
   config.middleware.use Rack::SslEnforcer, :redirect_to => 'https://example.org'
 
-You can also define specific regex patterns or paths or hosts to redirect.
+You can also define specific regex patterns or paths or hosts or methods to redirect.
 
   config.middleware.use Rack::SslEnforcer, :only => /^\/admin\//
   config.middleware.use Rack::SslEnforcer, :only => "/login"
@@ -42,7 +42,11 @@ You can also define specific regex patterns or paths or hosts to redirect.
   config.middleware.use Rack::SslEnforcer, :only_hosts => [/[www|api]\.example\.org$/, 'example.com']
   config.middleware.use Rack::SslEnforcer, :except_hosts => 'help.example.com'
   config.middleware.use Rack::SslEnforcer, :except_hosts => /[help|blog]\.example\.com$/
-
+  config.middleware.use Rack::SslEnforcer, :only_methods => 'POST'
+  config.middleware.use Rack::SslEnforcer, :only_methods => ['POST', 'PUT']
+  config.middleware.use Rack::SslEnforcer, :except_methods => 'GET'
+  config.middleware.use Rack::SslEnforcer, :except_methods => ['GET', 'HEAD']
+  
 Note: hosts options take precedence over the path options. See tests for examples.
 
 Use the :strict option to force http for all requests not matching your :only specification

--- a/lib/rack/ssl-enforcer.rb
+++ b/lib/rack/ssl-enforcer.rb
@@ -85,6 +85,11 @@ module Rack
           req.host == pattern
         when :except_hosts
           req.host != pattern
+        when :only_methods
+          req.env['REQUEST_METHOD'] == pattern
+        when :except_methods
+          req.env['REQUEST_METHOD'] != pattern
+        end
       end
     end
 

--- a/test/rack-ssl-enforcer_test.rb
+++ b/test/rack-ssl-enforcer_test.rb
@@ -1,7 +1,6 @@
 require 'helper'
 
 class TestRackSslEnforcer < Test::Unit::TestCase
-
   context 'that has no :redirect_to set' do
     setup { mock_app }
 
@@ -79,7 +78,6 @@ class TestRackSslEnforcer < Test::Unit::TestCase
       assert_equal ["id=1; path=/; secure", "token=abc; path=/; HttpOnly; secure"], last_response.headers['Set-Cookie'].split("\n")
     end
   end
-
 
   context 'that has :ssl_port set' do
     setup { mock_app :https_port => 9443 }
@@ -767,4 +765,35 @@ class TestRackSslEnforcer < Test::Unit::TestCase
     end
   end
 
+  context 'that has a string method as only_methods option' do
+    setup { mock_app :only_methods => 'POST' } 
+    
+    should 'respond with a ssl redirect for post method' do
+      post 'http://www.example.org/', 'param=value'
+      assert_equal 301, last_response.status
+      assert_equal 'https://www.example.org/', last_response.location      
+    end
+   
+    should 'respond not redirect ssl requests' do
+      get 'http://www.example.org/'
+      assert_equal 200, last_response.status
+      assert_equal 'Hello world!', last_response.body
+    end
+  end
+  
+  context 'that has a string method as except_methods option' do
+    setup { mock_app :except_methods => 'GET' } 
+
+    should 'respond with a ssl redirect for post method' do
+      post 'http://www.example.org/', 'param=value'
+      assert_equal 301, last_response.status
+      assert_equal 'https://www.example.org/', last_response.location      
+    end
+ 
+    should 'respond not redirect ssl requests' do
+      get 'http://www.example.org/'
+      assert_equal 200, last_response.status
+      assert_equal 'Hello world!', last_response.body
+    end
+  end
 end


### PR DESCRIPTION
For "methods" a 3rd type of options I've rewritten the enforce_ssl? method to generate all condition variants of options from a keys_by_type hash (maybe the variable should be named options_by_type or matcher_options_by_type).

Now we should only need 1 test context with one pair of matcher option types and could remove all the other contexts testing all possible variants.

So I also have not written new test contexts for testing variants like only_method & only_host & only.
