### PR TITLE
Ignoring certain paths

### DIFF
--- a/test/rack-ssl-enforcer_test.rb
+++ b/test/rack-ssl-enforcer_test.rb
@@ -275,6 +275,66 @@ class TestRackSslEnforcer < Test::Unit::TestCase
     end
   end
 
+  context ':ignore (Regex)' do
+    setup { mock_app :ignore => /^\/foo/}
+
+    should 'not redirect for http' do
+      get 'http://www.example.org/foo'
+      assert_equal 200, last_response.status
+      assert_equal 'Hello world!', last_response.body
+    end
+
+    should 'not redirect for https' do
+      get 'https://www.example.org/foo'
+      assert_equal 200, last_response.status
+      assert_equal 'Hello world!', last_response.body
+    end
+  end
+
+  context ':ignore (String)' do
+    setup { mock_app :ignore => '/foo'}
+
+    should 'not redirect for http' do
+      get 'http://www.example.org/foo'
+      assert_equal 200, last_response.status
+      assert_equal 'Hello world!', last_response.body
+    end
+
+    should 'not redirect for https' do
+      get 'https://www.example.org/foo'
+      assert_equal 200, last_response.status
+      assert_equal 'Hello world!', last_response.body
+    end
+  end
+
+  context ':ignore (Array)' do
+    setup { mock_app :ignore => [/^\/foo/,'/bar']}
+
+    should 'not redirect for http for /foo' do
+      get 'http://www.example.org/foo'
+      assert_equal 200, last_response.status
+      assert_equal 'Hello world!', last_response.body
+    end
+
+    should 'not redirect for https for /foo' do
+      get 'https://www.example.org/foo'
+      assert_equal 200, last_response.status
+      assert_equal 'Hello world!', last_response.body
+    end
+
+    should 'not redirect for http for /bar' do
+      get 'http://www.example.org/bar'
+      assert_equal 200, last_response.status
+      assert_equal 'Hello world!', last_response.body
+    end
+
+    should 'not redirect for https for /bar' do
+      get 'https://www.example.org/bar'
+      assert_equal 200, last_response.status
+      assert_equal 'Hello world!', last_response.body
+    end
+  end
+
   context ':only_hosts (Regex)' do
     setup { mock_app :only_hosts => /[www|api]\.example\.co\.uk$/ }
 


### PR DESCRIPTION
There are times when I don't care if an asset is served over http or https.  Take everything with /assets for example in rails.  With relative paths, I just want /assets to be served from whatever protocol is being used on that page instead of it always forcing to http or https.  This patch allows people to specify directories to ignore to serve the above use case.

If you have any questions or concerns, do not hesitate to ask.
