### PR TITLE
Add test for nested url ignores.

### DIFF
--- a/test/rack-ssl-enforcer_test.rb
+++ b/test/rack-ssl-enforcer_test.rb
@@ -307,6 +307,16 @@ class TestRackSslEnforcer < Test::Unit::TestCase
     end
   end
 
+  context ':ignore (Nested String)' do
+    setup { mock_app :only => '/foo', :ignore => '/foo/bar'}
+
+    should 'not redirect for nested url' do
+      get 'http://www.example.org/foo/bar'
+      assert_equal 200, last_response.status
+      assert_equal 'Hello world!', last_response.body
+    end
+  end
+
   context ':ignore (Array)' do
     setup { mock_app :ignore => [/^\/foo/,'/bar']}
 


### PR DESCRIPTION
Hey there,

I ran into a case where I needed to ignore a nesting of an enforced URL. I wasn't sure which rule would take precedence. Ended up forking and testing it out just to be sure. Thought you might want to keep the test. :)
