### PR TITLE
fix bug that was setting arrays as keys in default_options hash

### DIFF
--- a/lib/rack/ssl-enforcer.rb
+++ b/lib/rack/ssl-enforcer.rb
@@ -23,7 +23,9 @@ module Rack
         :https_port           => nil,
         :force_secure_cookies => true
       }
-      CONSTRAINTS_BY_TYPE.values.each { |constraint| default_options[constraint] = nil }
+      CONSTRAINTS_BY_TYPE.values.each do |constraints|
+        constraints.each { |constraint| default_options[constraint] = nil }
+      end
 
       @app, @options = app, default_options.merge(options)
     end


### PR DESCRIPTION
Lines 26-28 in `lib/rack/ssl-enforcer.rb` are causing the `default_options` hash to look like this:

```
{
  :redirect_to => nil,
  :redirect_code => nil,
  :strict => false,
  :mixed => false,
  :hsts => nil,
  :http_port => nil,
  :https_port => nil,
  :force_secure_cookies => true,
  [:only_hosts, :except_hosts] => nil,
  [:only, :except] => nil,
  [:only_methods, :except_methods] => nil
}
```

This fixes it to look like this:

```
{
  :redirect_to => nil,
  :redirect_code => nil,
  :strict => false,
  :mixed => false,
  :hsts => nil,
  :http_port => nil,
  :https_port => nil,
  :force_secure_cookies => true,
  :only_hosts => nil,
  :except_hosts => nil,
  :only => nil,
  :except => nil,
  :only_methods => nil,
  :except_methods => nil
}
```
