### PR TITLE
Keep flash on redirect

### DIFF
--- a/lib/rack/ssl-enforcer.rb
+++ b/lib/rack/ssl-enforcer.rb
@@ -76,6 +76,7 @@ module Rack
     end
 
     def modify_location_and_redirect
+      @request.session[:flash].keep if !@request.session.nil? && @request.session.key?('flash') && !@request.session['flash'].empty?
       location = "#{current_scheme}://#{@request.host}#{@request.fullpath}"
       location = replace_scheme(location, @scheme)
       location = replace_host(location, @options[:redirect_to])


### PR DESCRIPTION
When rack-ssl-enforcer redirects to ssl url from non-ssl url, or vice versa, flash object does not keep. Keeping the flash object was fixed.
