### PR TITLE
Allow for custom, default, or no body when redirecting

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,31 @@ config.middleware.use Rack::SslEnforcer, :only => '/login', :before_redirect => 
 }
 ```
 
+### Custom or empty response body
+
+The default response body is:
+
+```html
+<html><body>You are being <a href="https://www.example.org/">redirected</a>.</body></html>
+```
+
+To supply a custom message, provide a string as `:redirect_html`:
+
+```ruby
+config.middleware.use Rack::SslEnforcer, :redirect_html => 'Redirecting!'
+```
+
+To supply a series of responses for Rack to chunk, provide a [permissable Rack body object](http://rack.rubyforge.org/doc/SPEC.html):
+
+```ruby
+config.middleware.use Rack::SslEnforcer, :redirect_html => ['<html>','<body>','Hello!','</body>','</html>']
+```
+
+To supply an empty response body, provide :redirect_html as false:
+
+```ruby
+config.middleware.use Rack::SslEnforcer, :redirect_html => false
+```
 
 ## Deployment
 

--- a/lib/rack/ssl-enforcer.rb
+++ b/lib/rack/ssl-enforcer.rb
@@ -24,6 +24,7 @@ module Rack
         :http_port            => nil,
         :https_port           => nil,
         :force_secure_cookies => true,
+        :redirect_html        => nil,
         :before_redirect      => nil
       }
       CONSTRAINTS_BY_TYPE.values.each do |constraints|
@@ -94,8 +95,12 @@ module Rack
     end
 
     def redirect_to(location)
-      body = "<html><body>You are being <a href=\"#{location}\">redirected</a>.</body></html>"
-      [@options[:redirect_code] || 301, { 'Content-Type' => 'text/html', 'Location' => location }, [body]]
+      body = []
+      body << "<html><body>You are being <a href=\"#{location}\">redirected</a>.</body></html>" if @options[:redirect_html].nil?
+      body << @options[:redirect_html] if @options[:redirect_html].is_a?(String)
+      body = @options[:redirect_html] if @options[:redirect_html].respond_to?('each')
+
+      [@options[:redirect_code] || 301, { 'Content-Type' => 'text/html', 'Location' => location }, body]
     end
 
     def ssl_request?

--- a/test/rack-ssl-enforcer_test.rb
+++ b/test/rack-ssl-enforcer_test.rb
@@ -949,4 +949,41 @@ class TestRackSslEnforcer < Test::Unit::TestCase
     end
   end
 
+  context 'default output' do
+    setup { mock_app }
+
+    should 'produce default output when redirecting' do
+      get 'http://www.example.org/'
+      assert_equal 301, last_response.status
+      assert_equal last_response.body, '<html><body>You are being <a href="https://www.example.org/">redirected</a>.</body></html>'
+    end
+  end
+
+  context 'no output' do
+    setup { mock_app :redirect_html => false }
+
+    should 'not produce output when redirecting' do
+      get 'http://www.example.org/'
+      assert_equal 301, last_response.status
+      assert_empty last_response.body
+    end
+  end
+
+  context 'custom string output' do
+    setup { mock_app :redirect_html => "<html><body>Hello!</body></html>" }
+      should 'produce custom output when redirecting' do
+      get 'http://www.example.org/'
+      assert_equal 301, last_response.status
+      assert_equal last_response.body, '<html><body>Hello!</body></html>'
+    end
+  end
+
+  context 'custom object output' do
+    setup { mock_app :redirect_html => ['<html>','<body>','Hello!','</body>','</html>'] }
+      should 'produce custom output when redirecting' do
+      get 'http://www.example.org/'
+      assert_equal 301, last_response.status
+      assert_equal last_response.body, '<html><body>Hello!</body></html>'
+    end
+  end
 end


### PR DESCRIPTION
Allow the user to provide a custom response body. The option can be false for an empty body, a simple string, or any object that conforms to the [Rack body object requirements](http://rack.rubyforge.org/doc/SPEC.html).
