### PR TITLE
Ensure exact match for String rules

### DIFF
--- a/lib/rack/ssl-enforcer/constraint.rb
+++ b/lib/rack/ssl-enforcer/constraint.rb
@@ -6,23 +6,19 @@ class SslEnforcerConstraint
   end
 
   def matches?
-    if @rule.is_a?(String) && [:only, :except].include?(@name)
-      result = tested_string[0, @rule.size].send(operator, @rule)
+    if @rule.is_a?(String)
+      result = [@rule, "#{@rule}/"].include?(tested_string)
     else
-      result = tested_string.send(operator, @rule)
+      result = tested_string =~ @rule
     end
 
     negate_result? ? !result : result
   end
 
-private
+  private
 
   def negate_result?
     @name.to_s =~ /except/
-  end
-
-  def operator
-    @rule.is_a?(Regexp) ? "=~" : "=="
   end
 
   def tested_string

--- a/test/rack-ssl-enforcer_test.rb
+++ b/test/rack-ssl-enforcer_test.rb
@@ -175,10 +175,10 @@ class TestRackSslEnforcer < Test::Unit::TestCase
       assert_equal 'https://www.example.org/account', last_response.location
     end
 
-    should 'redirect to HTTPS for /account/public' do
+    should 'not redirect for /account/public' do
       get 'http://www.example.org/account/public'
-      assert_equal 301, last_response.status
-      assert_equal 'https://www.example.org/account/public', last_response.location
+      assert_equal 200, last_response.status
+      assert_equal 'Hello world!', last_response.body
     end
 
     should 'not redirect SSL requests for /account' do
@@ -189,6 +189,22 @@ class TestRackSslEnforcer < Test::Unit::TestCase
 
     should 'not redirect for /foo' do
       get 'http://www.example.org/foo'
+      assert_equal 200, last_response.status
+      assert_equal 'Hello world!', last_response.body
+    end
+  end
+
+  context ':only (String) of 1 char' do
+    setup { mock_app :only => "/" }
+
+    should 'redirect to HTTPS for /' do
+      get 'http://www.example.org/'
+      assert_equal 301, last_response.status
+      assert_equal 'https://www.example.org/', last_response.location
+    end
+
+    should 'not redirect for /account' do
+      get 'http://www.example.org/account'
       assert_equal 200, last_response.status
       assert_equal 'Hello world!', last_response.body
     end


### PR DESCRIPTION
For instance, `:only => '/account'` won't match
`'/account/login'` anymore (use `:only => %r{^/account}` instead).

@tobmatth I think this behavior is the expected one (as you told me in your email a while back) but since this isn't backward-compatible I didn't to push this change directly to master so we can decide if we want it, and if yes in which version should we include it (probably next major version)...
