### PR TITLE
Enable ignore blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ config.middleware.use Rack::SslEnforcer, :ignore => '/assets'
 
 # You can also combine multiple constraints
 config.middleware.use Rack::SslEnforcer, :only => '/cart', :ignore => %r{/assets}, :strict => true
+
+# And ignore based on blocks
+config.middleware.use Rack::SslEnforcer, :ignore => lambda { |request| request.env["HTTP_X_IGNORE_SSL_ENFORCEMENT"] == "magic" }
 ```
 
 ### Method constraints

--- a/lib/rack/ssl-enforcer/constraint.rb
+++ b/lib/rack/ssl-enforcer/constraint.rb
@@ -8,6 +8,8 @@ class SslEnforcerConstraint
   def matches?
     if @rule.is_a?(String) && [:only, :except].include?(@name)
       result = tested_string[0, @rule.size].send(operator, @rule)
+    elsif @rule.respond_to?(:call)
+      result = @rule.call(@request)
     else
       result = tested_string.send(operator, @rule)
     end

--- a/test/rack-ssl-enforcer_test.rb
+++ b/test/rack-ssl-enforcer_test.rb
@@ -344,6 +344,28 @@ class TestRackSslEnforcer < Test::Unit::TestCase
     end
   end
 
+  context ':ignore (block)' do
+    context 'when the block returns truthy' do
+      setup { mock_app :ignore => lambda { |request| true } }
+
+      should 'not redirect' do
+        get 'http://www.example.org/foo/bar'
+        assert_equal 200, last_response.status
+        assert_equal 'Hello world!', last_response.body
+      end
+    end
+
+    context 'when the block returns falsy' do
+      setup { mock_app :ignore => lambda { |request| false } }
+
+      should 'redirect' do
+        get 'http://www.example.org/foo/bar'
+        assert_equal 301, last_response.status
+        assert_equal 'https://www.example.org/foo/bar', last_response.location
+      end
+    end
+  end
+
   context ':ignore (Array)' do
     setup { mock_app :ignore => [/^\/foo/,'/bar']}
 


### PR DESCRIPTION
Allow :ignore options to be callables, intended to allow headers and other arbitrary request information to be considered when ignoring a request for ssl purposes.
