### PR TITLE
Do not encode already encoded url parameters when redirecting.

### DIFF
--- a/lib/rack/ssl-enforcer.rb
+++ b/lib/rack/ssl-enforcer.rb
@@ -109,7 +109,7 @@ module Rack
 
     def destination_host
       if @options[:redirect_to]
-        host_parts = URI.split(URI.encode(@options[:redirect_to]))
+        host_parts = URI.split(@options[:redirect_to])
         host_parts[2] || host_parts[5]
       end
     end
@@ -153,7 +153,7 @@ module Rack
       return uri if not scheme_mismatch?
 
       port = adjust_port_to(scheme)
-      uri_parts = URI.split(URI.encode(uri))
+      uri_parts = URI.split(uri)
       uri_parts[3] = port unless port.nil?
       uri_parts[0] = scheme
       URI::HTTP.new(*uri_parts).to_s
@@ -162,9 +162,9 @@ module Rack
     def replace_host(uri, host)
       return uri unless host_mismatch?
 
-      host_parts = URI.split(URI.encode(host))
+      host_parts = URI.split(host)
       new_host = host_parts[2] || host_parts[5]
-      uri_parts = URI.split(URI.encode(uri))
+      uri_parts = URI.split(uri)
       uri_parts[2] = new_host
       URI::HTTPS.new(*uri_parts).to_s
     end

--- a/test/rack-ssl-enforcer_test.rb
+++ b/test/rack-ssl-enforcer_test.rb
@@ -102,6 +102,12 @@ class TestRackSslEnforcer < Test::Unit::TestCase
       assert_equal 'https://www.google.com/admin?token=33', last_response.location
     end
 
+    should 'redirect to HTTPS and not re-encode the params' do
+      get 'http://www.example.org/admin?email=someone%40somedomain.com&link=http%3A%2F%2Fwww.someurl.com'
+      assert_equal 301, last_response.status
+      assert_equal 'https://www.google.com/admin?email=someone%40somedomain.com&link=http%3A%2F%2Fwww.someurl.com', last_response.location
+    end
+
     should 'redirect to HTTPS and append scheme automatically' do
       mock_app :redirect_to => 'www.google.com'
 


### PR DESCRIPTION
This reverts commit c39a72b11636360f5d6508209deaa045e0439ff4.

That commit was intended to stop rack ssl enforcer from erroring when it got a badly formed url, but it caused already encoded uri parameters to be encoded again.

This fixes #75, and also adds a test to verify that the parameters do not get double encoded.
