### PR TITLE
respect rack.url_scheme header for proxied SSL when HTTP_X_FORWARDED_PROTO blank

### DIFF
--- a/lib/rack/ssl-enforcer.rb
+++ b/lib/rack/ssl-enforcer.rb
@@ -119,7 +119,7 @@ module Rack
       if @request.env['HTTPS'] == 'on' || @request.env['HTTP_X_SSL_REQUEST'] == 'on'
         'https'
       elsif @request.env['HTTP_X_FORWARDED_PROTO']
-        @request.env['HTTP_X_FORWARDED_PROTO'].split(',')[0]
+        @request.env['HTTP_X_FORWARDED_PROTO'].split(',')[0] || @request.scheme
       else
         @request.scheme
       end

--- a/test/rack-ssl-enforcer_test.rb
+++ b/test/rack-ssl-enforcer_test.rb
@@ -18,6 +18,12 @@ class TestRackSslEnforcer < Test::Unit::TestCase
       assert_equal 'https://www.example.org/', last_response.location
     end
 
+    should 'respect rack.url_scheme header for proxied SSL when HTTP_X_FORWARDED_PROTO blank' do
+      get 'http://www.example.org/', {}, { 'HTTP_X_FORWARDED_PROTO' => '', 'rack.url_scheme' => 'http' }
+      assert_equal 301, last_response.status
+      assert_equal 'https://www.example.org/', last_response.location
+    end
+
     should 'not redirect SSL requests' do
       get 'https://www.example.org/'
       assert_equal 200, last_response.status


### PR DESCRIPTION
We currently have a setup where HTTP_X_FORWARDED_PROTO can be set but be blank. This change will hopefully allow for situations like this.