### PR TITLE
Add HSTS preload option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ pkg
 Gemfile.lock
 
 ## PROJECT::SPECIFIC
+.ruby-gemset
+.ruby-version

--- a/lib/rack/ssl-enforcer.rb
+++ b/lib/rack/ssl-enforcer.rb
@@ -47,7 +47,7 @@ module Rack
 
       if redirect_required?
         call_before_redirect
-        modify_location_and_redirect 
+        modify_location_and_redirect
       elsif ssl_request?
         status, headers, body = @app.call(env)
         flag_cookies_as_secure!(headers) if @options[:force_secure_cookies]
@@ -195,10 +195,11 @@ module Rack
 
     # see http://en.wikipedia.org/wiki/Strict_Transport_Security
     def set_hsts_headers!(headers)
-      opts = { :expires => 31536000, :subdomains => true }
+      opts = { :expires => 31536000, :subdomains => true, :preload => false }
       opts.merge!(@options[:hsts]) if @options[:hsts].is_a? Hash
       value  = "max-age=#{opts[:expires]}"
       value += "; includeSubDomains" if opts[:subdomains]
+      value += "; preload" if opts[:preload]
       headers.merge!({ 'Strict-Transport-Security' => value })
     end
 

--- a/test/rack-ssl-enforcer_test.rb
+++ b/test/rack-ssl-enforcer_test.rb
@@ -789,16 +789,21 @@ class TestRackSslEnforcer < Test::Unit::TestCase
   end
 
   context ':hsts' do
-    setup { mock_app :hsts => { :expires => '500', :subdomains => false } }
+    setup { mock_app :hsts => { :expires => '500', :subdomains => false, :preload => true } }
 
     should 'set expiry option' do
       get 'https://www.example.org/'
-      assert_equal "max-age=500", last_response.headers["Strict-Transport-Security"]
+      assert last_response.headers["Strict-Transport-Security"].include?("max-age=500")
     end
 
     should 'not include subdomains' do
       get 'https://www.example.org/'
       assert !last_response.headers["Strict-Transport-Security"].include?("includeSubDomains")
+    end
+
+    should 'set preload option' do
+      get 'https://www.example.org'
+      assert last_response.headers["Strict-Transport-Security"].include?("preload")
     end
   end
 


### PR DESCRIPTION
Support for the "preload" option in the HSTS cookie.  See https://www.owasp.org/index.php/HTTP_Strict_Transport_Security and http://www.chromium.org/hsts.

I added the .ruby-gemset and .ruby-version files to the .gitignore, but if you're OK with including those files in the project that could be adjusted.