### PR TITLE
Adding MIT license to the gemspec.

### DIFF
--- a/rack-ssl-enforcer.gemspec
+++ b/rack-ssl-enforcer.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |s|
   s.authors     = ['Tobias Matthies', 'Thibaud Guillaume-Gentil']
   s.email       = ['tm@mit2m.d', 'thibaud@thibaud.me']
   s.homepage    = 'http://github.com/tobmatth/rack-ssl-enforcer'
+  s.licenses    = ["MIT"]
   s.summary     = 'A simple Rack middleware to enforce SSL'
   s.description = 'Rack::SslEnforcer is a simple Rack middleware to enforce ssl connections'
 


### PR DESCRIPTION
I'm working on [VersionEye](https://www.versioneye.com/) and my goal is to build up a license db for RubyGems which is complete. To reduce the manual work I'm doing currently it would be awesome if this gemspec would contain the license information in future. Many Thanks.