### PR TITLE
Travis: Use jruby-9.1.10.0 in CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ rvm:
   - ruby-head
   - ree
   - rbx-2
-  - jruby-9.1.7.0
+  - jruby-9.1.10.0
 matrix:
   allow_failures:
     - rvm: ruby-head


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.