### PR TITLE
HSTS on Redirects

### DIFF
--- a/lib/rack/ssl-enforcer.rb
+++ b/lib/rack/ssl-enforcer.rb
@@ -102,7 +102,10 @@ module Rack
       body << @options[:redirect_html] if @options[:redirect_html].is_a?(String)
       body = @options[:redirect_html] if @options[:redirect_html].respond_to?('each')
 
-      [@options[:redirect_code] || 301, { 'Content-Type' => 'text/html', 'Location' => location }, body]
+      headers = { 'Content-Type' => 'text/html', 'Location' => location }
+      set_hsts_headers!(headers) if @options[:hsts] && !@options[:strict]
+
+      [@options[:redirect_code] || 301, headers, body]
     end
 
     def ssl_request?


### PR DESCRIPTION
In order to meet the letter of OMB M-15-13 and subsequent guidance (https://www.whitehouse.gov/sites/whitehouse.gov/files/omb/memoranda/2015/m-15-13.pdf; https://https.cio.gov/hsts/), all responses from a web server must append the strict-transport header with an appropriate max-age parameter.

Using this middleware supports HSTS, but not during redirects. This pull request addresses this gap by moving the static header string in the redirect_to method into a variable and augmenting the dictionary with a call to set_hsts_headers! based on user configurations.