### PR TITLE
use 'HTTP_FLY_FORWARDED_PROTO' to determine scheme.

### DIFF
--- a/lib/rack/ssl-enforcer.rb
+++ b/lib/rack/ssl-enforcer.rb
@@ -120,6 +120,8 @@ module Rack
     def current_scheme
       if @request.env['HTTPS'] == 'on' || @request.env['HTTP_X_SSL_REQUEST'] == 'on'
         'https'
+      elsif @request.env['HTTP_FLY_FORWARDED_PROTO']
+        @request.env['HTTP_FLY_FORWARDED_PROTO']
       elsif @request.env['HTTP_X_FORWARDED_PROTO']
         @request.env['HTTP_X_FORWARDED_PROTO'].split(',')[0] || @request.scheme
       else


### PR DESCRIPTION
I am using https://glitch.com/ and unfortunately even the `HTTP_X_FORWARDED_PROTO` is `https,https,https` when fetching http files.  however the `HTTP_FLY_FORWARDED_PROTO` is accurate and comes through as a simple `http` or `https`.  I am using this fork on my site right now, with `gem 'rack-ssl-enforcer', github: 'jubishop/rack-ssl-enforcer'` but would be happy to push this back into the main branch.  

For nearly all users this should have no impact, because this header won't exist.  But in the rare cases where it does,  it solves this bug.  